### PR TITLE
Fix OS X comment typo

### DIFF
--- a/bash/config
+++ b/bash/config
@@ -104,7 +104,7 @@ if [[ -x /usr/bin/dircolors || `which gdircolors` ]]; then
     alias egrep='egrep --color=auto'
 fi
 
-# For Max OS X set envvar that turns on terminal colors for BSD ls
+# For Mac OS X set envvar that turns on terminal colors for BSD ls
 if [[ `uname` == 'Darwin' ]]; then
     export CLICOLOR=1
 fi


### PR DESCRIPTION
## Summary
- fix small typo in bash config comment

## Testing
- `grep -n "OS X" -n bash/config`

------
https://chatgpt.com/codex/tasks/task_e_68685ded2070832c96f27be3bca6b5df