### PR TITLE
Fix big_pull function to avoid leaving working directory

### DIFF
--- a/bash/aliases
+++ b/bash/aliases
@@ -14,10 +14,13 @@ GREP_OPTIONS="-rI --color --exclude-dir=\.bzr --exclude-dir=\.git --exclude-dir=
 
 # Pull all git repositories in first argument (a dir)
 function big_pull {
-    find $1 -type d -name .git \
+    find "$1" -type d -name .git \
     | xargs -n 1 dirname \
     | sort \
-    | while read line; do echo $line && cd $line && git pull ; done
+    | while read line; do
+        echo "$line"
+        (cd "$line" && git pull)
+      done
 }
 
 #Sysadmin lols


### PR DESCRIPTION
## Summary
- fix `big_pull` alias to use subshells and quoting

## Testing
- `bash -n bash/aliases`
- `rake -T`

------
https://chatgpt.com/codex/tasks/task_e_68685d183064832c80e2b64cae5945f1